### PR TITLE
feat: add Python and Go multi-language publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,3 +129,77 @@ jobs:
         run: cd .repo && npx projen package:js
       - name: Collect js artifact
         run: mv .repo/dist dist
+  package-python:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ !needs.build.outputs.self_mutation_happened }}
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20.x
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create python artifact
+        run: cd .repo && npx projen package:python
+      - name: Collect python artifact
+        run: mv .repo/dist dist
+  package-go:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ !needs.build.outputs.self_mutation_happened }}
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20.x
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ^1.18.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - cdkdiffprgithubaction/**
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}
@@ -66,6 +68,8 @@ jobs:
     needs:
       - release
       - release_npm
+      - release_pypi
+      - release_golang
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -128,3 +132,90 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
+  release_pypi:
+    name: Publish to PyPI
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: read
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20.0.0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Download build artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create python artifact
+        run: cd .repo && npx projen package:python
+      - name: Collect python artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: npx -p publib@latest publib-pypi
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      packages: read
+    if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20.0.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ^1.18.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          path: .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Extract build artifact
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+      - name: Move build artifact out of the way
+        run: mv dist dist.old
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          GIT_USER_NAME: github-actions[bot]
+          GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+        run: npx -p publib@latest publib-golang

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -174,6 +174,21 @@
       "steps": [
         {
           "spawn": "package:js"
+        },
+        {
+          "spawn": "package:python"
+        },
+        {
+          "spawn": "package:go"
+        }
+      ]
+    },
+    "package:go": {
+      "name": "package:go",
+      "description": "Create go language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },
@@ -183,6 +198,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target js"
+        }
+      ]
+    },
+    "package:python": {
+      "name": "package:python",
+      "description": "Create python language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target python"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "eslint": "npx projen eslint",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
+    "package:go": "npx projen package:go",
     "package:js": "npx projen package:js",
+    "package:python": "npx projen package:python",
     "post-compile": "npx projen post-compile",
     "post-upgrade": "npx projen post-upgrade",
     "pre-compile": "npx projen pre-compile",
@@ -158,7 +160,16 @@
   "stability": "experimental",
   "jsii": {
     "outdir": "dist",
-    "targets": {},
+    "targets": {
+      "python": {
+        "distName": "jjrawlins-cdk-diff-pr-github-action",
+        "module": "jjrawlins_cdk_diff_pr_github_action"
+      },
+      "go": {
+        "moduleName": "github.com/JaysonRawlins/cdk-diff-pr-github-action",
+        "packageName": "cdkdiffprgithubaction"
+      }
+    },
     "tsc": {
       "outDir": "lib",
       "rootDir": "src"


### PR DESCRIPTION
## Summary
- Configure jsii targets to publish the CDK construct library to **PyPI** (`jjrawlins-cdk-diff-pr-github-action`) and as a **Go module** (`github.com/JaysonRawlins/cdk-diff-pr-github-action`)
- Follows the same pattern as `cdk-deploy-pr-github-action` — Go publishes to the same repo with `paths-ignore` to prevent release retrigger
- .NET (NuGet) not possible because `projen` lacks a `dotnet` jsii target

## Changes
- `.projenrc.ts`: Add `publishToPypi`, `publishToGo` config + workflow overrides for new jobs
- Generated: `build.yml` (package-python, package-go jobs), `release.yml` (release_pypi, release_golang jobs + paths-ignore), `tasks.json`, `package.json` (jsii targets)

## Required secrets (before first release)
- `TWINE_USERNAME` + `TWINE_PASSWORD` for PyPI
- `GO_GITHUB_TOKEN` for Go module publishing

## Test plan
- [x] `npx projen build` passes locally (all 49 tests, JS/Python/Go packaging)
- [ ] CI build workflow passes
- [ ] Verify generated workflow files have correct permissions and checkout refs