### PR TITLE
fix: use Node 20.x for PyPI and Go release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: 20.0.0
+          node-version: 20.x
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -187,7 +187,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: 20.0.0
+          node-version: 20.x
       - uses: actions/setup-go@v6
         with:
           go-version: ^1.18.0

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -205,15 +205,17 @@ releaseWorkflow.file!.addOverride('jobs.release_npm.steps.0.with.node-version', 
 // Add --ignore-engines to yarn install since Node 24 is outside the engines range (20.x)
 releaseWorkflow.file!.addOverride('jobs.release_npm.steps.4.run', 'cd .repo && yarn install --check-files --frozen-lockfile --ignore-engines');
 
-// PyPI release permissions
+// PyPI release permissions and node version
 releaseWorkflow.file!.addOverride('jobs.release_pypi.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_pypi.permissions.packages', 'read');
 releaseWorkflow.file!.addOverride('jobs.release_pypi.permissions.contents', 'write');
+releaseWorkflow.file!.addOverride('jobs.release_pypi.steps.0.with.node-version', workflowNodeVersion);
 
-// Go release permissions
+// Go release permissions and node version
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.id-token', 'write');
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.packages', 'read');
 releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.contents', 'write');
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.0.with.node-version', workflowNodeVersion);
 
 // Prevent release workflow from triggering on Go module commits
 releaseWorkflow.file!.addOverride('on.push.paths-ignore', [


### PR DESCRIPTION
## Summary
- Override node-version from `20.0.0` (projen default) to `20.x` for `release_pypi` and `release_golang` jobs
- Fixes `@eslint/plugin-kit@0.3.5` engine check failure (`^20.9.0` required, `20.0.0` provided)
- Same pattern already applied to all other workflow jobs

## Test plan
- [x] `npx projen build` passes locally
- [ ] CI build passes
- [ ] Release workflow succeeds for PyPI and Go jobs