### PR TITLE
feat: add preGitHubSteps and postGitHubSteps

### DIFF
--- a/API.md
+++ b/API.md
@@ -796,6 +796,8 @@ const cdkDiffStackWorkflowProps: CdkDiffStackWorkflowProps = { ... }
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.nodeVersion">nodeVersion</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.oidcRegion">oidcRegion</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.oidcRoleArn">oidcRoleArn</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.postGitHubSteps">postGitHubSteps</a></code> | <code>any</code> | Additional GitHub Actions steps to run after all CDK operations complete. |
+| <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.preGitHubSteps">preGitHubSteps</a></code> | <code>any</code> | Additional GitHub Actions steps to run before CDK operations (after install, before AWS creds). |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.scriptOutputPath">scriptOutputPath</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.workingDirectory">workingDirectory</a></code> | <code>string</code> | Working directory for the CDK app, relative to the repository root. |
 
@@ -861,6 +863,42 @@ public readonly oidcRoleArn: string;
 
 ---
 
+##### `postGitHubSteps`<sup>Optional</sup> <a name="postGitHubSteps" id="@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.postGitHubSteps"></a>
+
+```typescript
+public readonly postGitHubSteps: any;
+```
+
+- *Type:* any
+
+Additional GitHub Actions steps to run after all CDK operations complete.
+
+Accepts a static array of steps, or a factory function receiving context:
+`(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+
+When `workingDirectory` is set, all `run:` steps inherit that directory.
+To run a step at the repository root, add `working-directory: '.'` to that step.
+
+---
+
+##### `preGitHubSteps`<sup>Optional</sup> <a name="preGitHubSteps" id="@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.preGitHubSteps"></a>
+
+```typescript
+public readonly preGitHubSteps: any;
+```
+
+- *Type:* any
+
+Additional GitHub Actions steps to run before CDK operations (after install, before AWS creds).
+
+Accepts a static array of steps, or a factory function receiving context:
+`(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+
+When `workingDirectory` is set, all `run:` steps inherit that directory.
+To run a step at the repository root, add `working-directory: '.'` to that step.
+
+---
+
 ##### `scriptOutputPath`<sup>Optional</sup> <a name="scriptOutputPath" id="@jjrawlins/cdk-diff-pr-github-action.CdkDiffStackWorkflowProps.property.scriptOutputPath"></a>
 
 ```typescript
@@ -910,6 +948,7 @@ const cdkDriftDetectionWorkflowProps: CdkDriftDetectionWorkflowProps = { ... }
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.oidcRegion">oidcRegion</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.oidcRoleArn">oidcRoleArn</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.postGitHubSteps">postGitHubSteps</a></code> | <code>any</code> | Optional additional GitHub Action steps to run after drift detection for each stack. |
+| <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.preGitHubSteps">preGitHubSteps</a></code> | <code>any</code> | Additional GitHub Actions steps to run before drift detection (after install, before AWS creds). |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.schedule">schedule</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.scriptOutputPath">scriptOutputPath</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.workflowName">workflowName</a></code> | <code>string</code> | *No description.* |
@@ -990,6 +1029,27 @@ Optional additional GitHub Action steps to run after drift detection for each st
 These steps run after results are uploaded for each stack. You can include
 any notifications you like (e.g., Slack). Provide explicit inputs (e.g., payload/markdown)
 directly in your step without relying on a pre-generated payload.
+
+---
+
+##### `preGitHubSteps`<sup>Optional</sup> <a name="preGitHubSteps" id="@jjrawlins/cdk-diff-pr-github-action.CdkDriftDetectionWorkflowProps.property.preGitHubSteps"></a>
+
+```typescript
+public readonly preGitHubSteps: any;
+```
+
+- *Type:* any
+
+Additional GitHub Actions steps to run before drift detection (after install, before AWS creds).
+
+Accepts a static array of steps, or a factory function receiving context:
+`(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+
+When `workingDirectory` is set, all `run:` steps inherit that directory.
+To run a step at the repository root, add `working-directory: '.'` to that step.
+
+Pre-steps automatically receive the stack-selection condition (`if`) so they
+only run when the stack is selected via dispatch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ project.synth();
 - `cdkYarnCommand` (optional, default `'cdk'`) — Yarn script/command to invoke CDK.
 - `scriptOutputPath` (optional, default `'.github/workflows/scripts/describe-cfn-changeset.ts'`) — Where to write the helper script.
 - `workingDirectory` (optional) — Subdirectory where the CDK app lives (e.g., `'infra'`). Sets `defaults.run.working-directory` on all jobs so `install`, `synth`, and `deploy` steps run in that directory. The describe-changeset script path is automatically prefixed with `$GITHUB_WORKSPACE/` and `NODE_PATH` is set to resolve modules from the working directory.
+- `preGitHubSteps` (optional) — Additional steps to run after install but before AWS credentials and CDK operations. Accepts a static array or a factory `({ stack, workingDirectory }) => steps[]`.
+- `postGitHubSteps` (optional) — Additional steps to run after all CDK operations complete. Accepts a static array or a factory `({ stack, workingDirectory }) => steps[]`.
 
 If neither top‑level OIDC defaults nor all per‑stack values are supplied, the construct throws a helpful error.
 
@@ -465,6 +467,8 @@ project.synth();
 - `nodeVersion` (optional, default `'24.x'`) — Node.js version for the runner.
 - `scriptOutputPath` (optional, default `'.github/workflows/scripts/detect-drift.ts'`) — Where to write the helper script.
 - `workingDirectory` (optional) — Subdirectory where the CDK app lives (e.g., `'infra'`). Sets `defaults.run.working-directory` on all jobs. Artifact upload and issue-script paths are automatically prefixed.
+- `preGitHubSteps` (optional) — Additional steps to run after install but before AWS credentials and drift detection. Accepts a static array or a factory `({ stack, workingDirectory }) => steps[]`. Pre-steps automatically receive the stack-selection condition so they only run when the stack is selected.
+- `postGitHubSteps` (optional) — Additional steps to run after drift detection and issue creation. Accepts a static array or a factory `({ stack, workingDirectory }) => steps[]`. Steps default to `if: always() && steps.drift.outcome == 'failure'` unless you provide your own `if`.
 
 ### Per‑stack fields
 - `stackName` (required) — The full CloudFormation stack name.
@@ -792,6 +796,31 @@ new CdkDriftDetectionWorkflow({
 This sets `defaults.run.working-directory: infra` on all workflow jobs so that `install`, `synth`, and `deploy` steps run in the correct directory. The describe-changeset and detect-drift scripts are referenced with absolute paths so they resolve correctly from the subdirectory.
 
 **Note:** Your `infra/package.json` must include `@aws-sdk/client-cloudformation` as a dependency for the describe-changeset script to resolve modules at runtime.
+
+## Pre/post workflow steps
+
+Both `CdkDiffStackWorkflow` and `CdkDriftDetectionWorkflow` support `preGitHubSteps` and `postGitHubSteps` for running custom steps before and after CDK operations. This is useful for building source code, sending Slack notifications, or running arbitrary commands.
+
+You can provide a static array of steps, or a factory function that receives context:
+
+```ts
+new CdkDiffStackWorkflow({
+  project,
+  workingDirectory: 'infra',
+  oidcRoleArn: 'arn:aws:iam::111111111111:role/GitHubOIDCRole',
+  oidcRegion: 'us-east-1',
+  stacks: [/* ... */],
+  preGitHubSteps: ({ stack, workingDirectory }) => [
+    // Build at project root (overrides working-directory default)
+    { name: 'Build app', run: 'npm run build', 'working-directory': '.' },
+  ],
+  postGitHubSteps: ({ stack }) => [
+    { name: 'Notify Slack', uses: 'slackapi/slack-github-action@v2', with: { /* ... */ } },
+  ],
+});
+```
+
+> **Note:** When `workingDirectory` is set, all `run:` steps inherit that directory by default. To run a step at the repository root, add `working-directory: '.'` to that step.
 
 ## Notes
 - This package assumes your repository is configured with GitHub Actions and that you have a GitHub OIDC role configured in AWS.

--- a/src/CdkDiffStackWorkflow.ts
+++ b/src/CdkDiffStackWorkflow.ts
@@ -8,6 +8,18 @@ const githubActionsSetupNodeVersion = 'v4';
 
 const MAX_WORKFLOW_FILENAME_LENGTH = 255;
 
+type GitHubStep = {
+  name?: string;
+  id?: string;
+  if?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  env?: Record<string, string>;
+  continueOnError?: boolean;
+  shell?: string;
+};
+
 export interface CdkDiffStack {
   readonly stackName: string;
   readonly changesetRoleToAssumeArn: string;
@@ -34,6 +46,24 @@ export interface CdkDiffStackWorkflowProps {
    * @default - repository root
    */
   readonly workingDirectory?: string;
+  /**
+   * Additional GitHub Actions steps to run before CDK operations (after install, before AWS creds).
+   * Accepts a static array of steps, or a factory function receiving context:
+   * `(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+   *
+   * When `workingDirectory` is set, all `run:` steps inherit that directory.
+   * To run a step at the repository root, add `working-directory: '.'` to that step.
+   */
+  readonly preGitHubSteps?: any;
+  /**
+   * Additional GitHub Actions steps to run after all CDK operations complete.
+   * Accepts a static array of steps, or a factory function receiving context:
+   * `(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+   *
+   * When `workingDirectory` is set, all `run:` steps inherit that directory.
+   * To run a step at the repository root, add `working-directory: '.'` to that step.
+   */
+  readonly postGitHubSteps?: any;
 }
 export class CdkDiffStackWorkflow {
   private static scriptCreated = false;
@@ -70,6 +100,7 @@ export class CdkDiffStackWorkflow {
       this.createWorkflowForStack(
         diffDeployWorkflow, stack, cdkYarnCommand, nodeVersion,
         scriptOutputPath, defaults, props.oidcRoleArn, props.oidcRegion,
+        props.preGitHubSteps, props.postGitHubSteps,
       );
     }
   }
@@ -101,10 +132,17 @@ export class CdkDiffStackWorkflow {
     defaults: { run: { workingDirectory: string } } | undefined,
     defaultOidcRoleArn?: string,
     defaultOidcRegion?: string,
+    rawPreSteps?: any,
+    rawPostSteps?: any,
   ) {
     // Sanitize stack name for CloudFormation API calls (must match [a-zA-Z][-a-zA-Z0-9]*, max 128 chars)
     // Original stack.stackName is preserved only for the CDK deploy target and step display names
     const sanitizedStackName = sanitizeForCloudFormation(stack.stackName);
+
+    // Resolve pre/post steps (accept static array or factory function)
+    const ctx = { stack: sanitizedStackName, workingDirectory: defaults?.run.workingDirectory };
+    const preSteps: GitHubStep[] = typeof rawPreSteps === 'function' ? rawPreSteps(ctx) : (rawPreSteps ?? []);
+    const postSteps: GitHubStep[] = typeof rawPostSteps === 'function' ? rawPostSteps(ctx) : (rawPostSteps ?? []);
 
     // When working directory is set, the describe-changeset step overrides back to repo root
     // because the script needs root-level ts-node, tsconfig.json, and node_modules (e.g. @aws-sdk)
@@ -156,6 +194,7 @@ export class CdkDiffStackWorkflow {
               NODE_AUTH_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
             },
           },
+          ...preSteps,
           {
             uses: `aws-actions/configure-aws-credentials@${githubActionsAwsCredentialsVersion}`,
             with: {
@@ -230,6 +269,7 @@ export class CdkDiffStackWorkflow {
             name: `Delete changeset for ${stack.stackName}`,
             run: `aws cloudformation delete-change-set --change-set-name ${sanitizedStackName} --stack-name "\${{ steps.create-changeset.outputs.cf-stack-name }}" --region ${stack.changesetRoleToAssumeRegion}`,
           },
+          ...postSteps,
         ],
       },
     });

--- a/src/CdkDriftDetectionWorkflow.ts
+++ b/src/CdkDriftDetectionWorkflow.ts
@@ -52,9 +52,21 @@ export interface CdkDriftDetectionWorkflowProps {
    */
   // NOTE: jsii does not support function types in public APIs; use 'any' here and accept either:
   // - An array of GitHub steps, or
-  // - A function (ctx: { stack: string }) => GitHubStep[]
+  // - A function (ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]
   // The constructor handles both at runtime.
   readonly postGitHubSteps?: any;
+  /**
+   * Additional GitHub Actions steps to run before drift detection (after install, before AWS creds).
+   * Accepts a static array of steps, or a factory function receiving context:
+   * `(ctx: { stack: string; workingDirectory?: string }) => GitHubStep[]`
+   *
+   * When `workingDirectory` is set, all `run:` steps inherit that directory.
+   * To run a step at the repository root, add `working-directory: '.'` to that step.
+   *
+   * Pre-steps automatically receive the stack-selection condition (`if`) so they
+   * only run when the stack is selected via dispatch.
+   */
+  readonly preGitHubSteps?: any;
 }
 
 type GitHubStep = {
@@ -127,8 +139,11 @@ export class CdkDriftDetectionWorkflow {
       const condExpr = '${{ ' + innerCond + ' }}';
       const notCondExpr = '${{ !(' + innerCond + ') }}';
 
+      const stepCtx = { stack: sanitizedStackName, workingDirectory: wd };
+      const rawPre = props.preGitHubSteps;
+      const preSteps: GitHubStep[] = typeof rawPre === 'function' ? rawPre(stepCtx) : (rawPre ?? []);
       const rawPost = props.postGitHubSteps;
-      const postSteps: GitHubStep[] = typeof rawPost === 'function' ? (rawPost as (ctx: { stack: string }) => GitHubStep[])({ stack: sanitizedStackName }) : (rawPost ?? []);
+      const postSteps: GitHubStep[] = typeof rawPost === 'function' ? rawPost(stepCtx) : (rawPost ?? []);
 
       // Prefix results file path for uses: steps (which ignore defaults.run.working-directory)
       const artifactResultsPath = wd ? `${wd}/${resultsFile}` : resultsFile;
@@ -161,6 +176,11 @@ export class CdkDriftDetectionWorkflow {
             with: { 'node-version': nodeVersion },
           },
           { name: 'Install dependencies', if: condExpr, run: 'yarn install --frozen-lockfile || npm ci', env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' } },
+          ...preSteps.map((step) => {
+            const s: any = { ...(step as any) };
+            s.if = s.if ?? condExpr;
+            return s;
+          }),
           {
             name: 'AWS Credentials',
             if: condExpr,

--- a/test/CdkDiffStackWorkflow.test.ts
+++ b/test/CdkDiffStackWorkflow.test.ts
@@ -401,6 +401,130 @@ describe('CdkDiffStackWorkflow', () => {
     expect(wf).not.toContain('NODE_PATH');
   });
 
+  test('preGitHubSteps factory receives { stack, workingDirectory } context', () => {
+    const app = createApp();
+    const receivedCtx: any[] = [];
+
+    new CdkDiffStackWorkflow({
+      project: app,
+      stacks: [
+        {
+          stackName: 'MyStack',
+          changesetRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-diff-role',
+          changesetRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      workingDirectory: 'infra',
+      preGitHubSteps: (ctx: any) => {
+        receivedCtx.push(ctx);
+        return [{ name: 'Pre step', run: 'echo pre' }];
+      },
+    });
+
+    expect(receivedCtx).toHaveLength(1);
+    expect(receivedCtx[0].stack).toBe('MyStack');
+    expect(receivedCtx[0].workingDirectory).toBe('infra');
+
+    const out = synthSnapshot(app);
+    const wf = out['.github/workflows/diff-mystack.yml'].toString();
+    expect(wf).toContain('name: Pre step');
+  });
+
+  test('postGitHubSteps factory receives { stack, workingDirectory } context', () => {
+    const app = createApp();
+    const receivedCtx: any[] = [];
+
+    new CdkDiffStackWorkflow({
+      project: app,
+      stacks: [
+        {
+          stackName: 'MyStack',
+          changesetRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-diff-role',
+          changesetRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      postGitHubSteps: (ctx: any) => {
+        receivedCtx.push(ctx);
+        return [{ name: 'Post step', run: 'echo post' }];
+      },
+    });
+
+    expect(receivedCtx).toHaveLength(1);
+    expect(receivedCtx[0].stack).toBe('MyStack');
+    expect(receivedCtx[0].workingDirectory).toBeUndefined();
+
+    const out = synthSnapshot(app);
+    const wf = out['.github/workflows/diff-mystack.yml'].toString();
+    expect(wf).toContain('name: Post step');
+  });
+
+  test('static array preGitHubSteps and postGitHubSteps are inserted correctly', () => {
+    const app = createApp();
+
+    new CdkDiffStackWorkflow({
+      project: app,
+      stacks: [
+        {
+          stackName: 'MyStack',
+          changesetRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-diff-role',
+          changesetRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      preGitHubSteps: [{ name: 'Build app', run: 'npm run build' }],
+      postGitHubSteps: [{ name: 'Notify Slack', uses: 'slackapi/slack-github-action@v2' }],
+    });
+
+    const out = synthSnapshot(app);
+    const wf = out['.github/workflows/diff-mystack.yml'].toString();
+
+    // Pre-steps appear before AWS creds
+    const preIdx = wf.indexOf('name: Build app');
+    const credsIdx = wf.indexOf('aws-actions/configure-aws-credentials');
+    expect(preIdx).toBeGreaterThan(-1);
+    expect(credsIdx).toBeGreaterThan(preIdx);
+
+    // Post-steps appear after delete changeset
+    const deleteIdx = wf.indexOf('Delete changeset for MyStack');
+    const postIdx = wf.indexOf('name: Notify Slack');
+    expect(postIdx).toBeGreaterThan(deleteIdx);
+  });
+
+  test('pre/post steps do not get a default if condition', () => {
+    const app = createApp();
+
+    new CdkDiffStackWorkflow({
+      project: app,
+      stacks: [
+        {
+          stackName: 'MyStack',
+          changesetRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-diff-role',
+          changesetRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      preGitHubSteps: [{ name: 'My pre step', run: 'echo pre' }],
+      postGitHubSteps: [{ name: 'My post step', run: 'echo post' }],
+    });
+
+    const out = synthSnapshot(app);
+    const wf = out['.github/workflows/diff-mystack.yml'].toString();
+
+    // Find the pre step and check it has no if condition injected
+    const preNameIdx = wf.indexOf('name: My pre step');
+    const preSnippet = wf.substring(preNameIdx, preNameIdx + 200);
+    // Next step name after pre step
+    const nextStepIdx = preSnippet.indexOf('aws-actions/configure-aws-credentials');
+    const preSection = nextStepIdx > 0 ? preSnippet.substring(0, nextStepIdx) : preSnippet;
+    expect(preSection).not.toContain('if:');
+  });
+
   test('changeset names exceeding 128 chars are truncated from the beginning', () => {
     const app = createApp();
 

--- a/test/CdkDriftDetectionWorkflow.test.ts
+++ b/test/CdkDriftDetectionWorkflow.test.ts
@@ -69,6 +69,74 @@ describe('CdkDriftDetectionWorkflow postGitHubSteps (Slack example)', () => {
     expect(snippet).toContain("if: always() && steps.drift.outcome == 'failure'");
   });
 
+  test('preGitHubSteps factory receives { stack, workingDirectory } and gets condExpr default if', () => {
+    const app = createApp();
+    const receivedCtx: any[] = [];
+
+    new CdkDriftDetectionWorkflow({
+      project: app,
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      workingDirectory: 'infra',
+      stacks: [
+        {
+          stackName: 'TestStack',
+          driftDetectionRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-drift-role',
+          driftDetectionRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      preGitHubSteps: (ctx: any) => {
+        receivedCtx.push(ctx);
+        return [{ name: 'Build app', run: 'npm run build' }];
+      },
+    });
+
+    expect(receivedCtx).toHaveLength(1);
+    expect(receivedCtx[0].stack).toBe('teststack');
+    expect(receivedCtx[0].workingDirectory).toBe('infra');
+
+    const out = synthSnapshot(app);
+    const wf = out['.github/workflows/drift-detection.yml'].toString();
+
+    // Pre-step should appear before AWS Credentials
+    const preIdx = wf.indexOf('name: Build app');
+    const credsIdx = wf.indexOf('name: AWS Credentials');
+    expect(preIdx).toBeGreaterThan(-1);
+    expect(credsIdx).toBeGreaterThan(preIdx);
+
+    // Pre-step should have the stack-selection condition applied as default
+    const preSnippet = wf.substring(preIdx, preIdx + 500);
+    expect(preSnippet).toContain('if:');
+    expect(preSnippet).toContain("github.event.inputs.stack == 'all'");
+  });
+
+  test('postGitHubSteps factory receives workingDirectory in context', () => {
+    const app = createApp();
+    const receivedCtx: any[] = [];
+
+    new CdkDriftDetectionWorkflow({
+      project: app,
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+      workingDirectory: 'infra',
+      stacks: [
+        {
+          stackName: 'TestStack',
+          driftDetectionRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-drift-role',
+          driftDetectionRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      postGitHubSteps: (ctx: any) => {
+        receivedCtx.push(ctx);
+        return [{ name: 'Post step', run: 'echo done' }];
+      },
+    });
+
+    expect(receivedCtx).toHaveLength(1);
+    expect(receivedCtx[0].stack).toBe('teststack');
+    expect(receivedCtx[0].workingDirectory).toBe('infra');
+  });
+
   test("includes an 'all' option and runs all stacks when selected", () => {
     const app = createApp();
 


### PR DESCRIPTION
## Summary

- Adds `preGitHubSteps` and `postGitHubSteps` to `CdkDiffStackWorkflow` and `CdkDriftDetectionWorkflow`
- Both accept a static array of steps or a factory function `({ stack, workingDirectory }) => steps[]`
- Pre-steps inserted after install, before AWS credentials
- Post-steps appended after all CDK operations
- Drift pre-steps automatically receive the stack-selection condition
- Drift post-steps context now includes `workingDirectory`

## Test plan

- [x] All 61 existing tests pass
- [x] New tests verify factory context, static arrays, step ordering, and no default `if` on diff pre/post
- [x] Full `npm run build` passes (compile + test + lint + package)