### PR TITLE
chore(ci): set upgrade-main workflow to weekly schedule

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 9 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,6 +1,6 @@
 import { awscdk, TextFile, DependencyType } from 'projen';
 import { GithubCredentials, workflows } from 'projen/lib/github';
-import { NpmAccess } from 'projen/lib/javascript';
+import { NpmAccess, UpgradeDependenciesSchedule } from 'projen/lib/javascript';
 const cdkCliVersion = '2.1029.2';
 const minNodeVersion = '20.0.0';
 const devNodeVersion = '20.19.0';
@@ -56,6 +56,11 @@ const project = new awscdk.AwsCdkConstructLibrary({
     },
   },
   depsUpgrade: true,
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: UpgradeDependenciesSchedule.expressions(['0 9 * * 1']),
+    },
+  },
   peerDeps: [
     `aws-cdk-lib@>=${cdkVersion} <3.0.0`,
     `constructs@>=${minConstructsVersion} <11.0.0`,


### PR DESCRIPTION
## Summary
- Change dependency upgrade schedule from daily (`0 0 * * *`) to weekly Monday 9am UTC (`0 9 * * 1`)