### PR TITLE
fix(ci): remove auto-merge and add dependency audit gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files
-      - name: Audit bundled dependencies
-        run: npx audit-ci --critical --report-type summary
       - name: build
         run: npx projen build
       - name: Find mutations

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files
+      - name: Audit bundled dependencies
+        run: npx audit-ci --critical --report-type summary
       - name: build
         run: npx projen build
       - name: Find mutations

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -27,6 +27,8 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
+      - name: Audit bundled dependencies
+        run: npx audit-ci --critical --report-type summary
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations
@@ -103,8 +105,3 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           signoff: true
-      - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number != ''
-        run: gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -27,8 +27,6 @@ jobs:
           node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
-      - name: Audit bundled dependencies
-        run: npx audit-ci --critical --report-type summary
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -167,15 +167,10 @@ project.github!.tryFindWorkflow('upgrade-main')!.file!.addOverride('jobs.pr.perm
 project.github!.tryFindWorkflow('upgrade-main')!.file!.addOverride('jobs.pr.permissions.pull-requests', 'write');
 project.github!.tryFindWorkflow('upgrade-main')!.file!.addOverride('jobs.pr.permissions.contents', 'write');
 
-// Add auto-merge step to upgrade-main workflow (step index 6, after PR creation)
-project.github!.tryFindWorkflow('upgrade-main')!.file!.addOverride('jobs.pr.steps.6', {
-  name: 'Enable auto-merge',
-  if: "steps.create-pr.outputs.pull-request-number != ''",
-  run: 'gh pr merge --auto --squash "${{ steps.create-pr.outputs.pull-request-number }}"',
-  env: {
-    GH_TOKEN: '${{ steps.generate_token.outputs.token }}',
-  },
-});
+// Note: audit-ci and auto-merge removal are applied directly to the generated YAML.
+// The "Audit bundled dependencies" step is added after "Install dependencies" in both
+// upgrade-main.yml and build.yml, and the "Enable auto-merge" step is removed from
+// upgrade-main.yml. These changes are maintained in the workflow files directly.
 
 /**
  * For the build job, we need to be able to read from packages and also need id-token permissions for OIDC to authenticate to the registry.
@@ -185,8 +180,8 @@ project.github!.tryFindWorkflow('build')!.file!.addOverride('jobs.build.permissi
 project.github!.tryFindWorkflow('build')!.file!.addOverride('jobs.build.permissions.packages', 'read');
 
 /**
- * Fix checkout to use SHA instead of branch ref (survives branch deletion after automerge).
- * When automerge deletes the head branch before workflow jobs complete, using the branch ref fails.
+ * Fix checkout to use SHA instead of branch ref (survives branch deletion after merge).
+ * When merge deletes the head branch before workflow jobs complete, using the branch ref fails.
  * The commit SHA persists even after branch deletion.
  */
 const buildWorkflow = project.github!.tryFindWorkflow('build')!;


### PR DESCRIPTION
## Summary

- **Remove auto-merge** from the `upgrade-main` workflow. Auto-merging dependency upgrade PRs is a supply chain risk — a compromised or malicious dependency update could be merged without human review.
- **Add `audit-ci` gate** to both `upgrade-main` and `build` workflows. The new "Audit bundled dependencies" step runs `npx audit-ci --critical --report-type summary` after dependency installation, blocking the workflow if any critical vulnerabilities are detected.
- **Update `.projenrc.ts`** to remove the auto-merge override and document that the audit-ci steps are maintained directly in the workflow YAML files.

## Test plan

- [ ] Verify `upgrade-main` workflow no longer contains the "Enable auto-merge" step
- [ ] Verify `upgrade-main` workflow has the "Audit bundled dependencies" step after "Install dependencies"
- [ ] Verify `build` workflow has the "Audit bundled dependencies" step after "Install dependencies"
- [ ] Confirm no other workflow files contain `gh pr merge --auto` patterns
- [ ] Trigger a build workflow run to confirm `audit-ci` executes successfully