### PR TITLE
feat: support pnpm projects in diff and drift workflows

### DIFF
--- a/src/CdkDiffStackWorkflow.ts
+++ b/src/CdkDiffStackWorkflow.ts
@@ -182,12 +182,15 @@ export class CdkDiffStackWorkflow {
           {
             name: 'Install dependencies',
             run: [
-              'if [ -f yarn.lock ]; then',
+              'if [ -f pnpm-lock.yaml ]; then',
+              '  corepack enable',
+              '  pnpm install --frozen-lockfile',
+              'elif [ -f yarn.lock ]; then',
               '  yarn install --frozen-lockfile',
               'elif [ -f package-lock.json ]; then',
               '  npm ci',
               'else',
-              '  echo "No lock file found (yarn.lock or package-lock.json)" && exit 1',
+              '  echo "No lock file found (pnpm-lock.yaml, yarn.lock, or package-lock.json)" && exit 1',
               'fi',
             ].join('\n'),
             env: {
@@ -207,7 +210,9 @@ export class CdkDiffStackWorkflow {
             id: 'create-changeset',
             run: [
               'set -o pipefail',
-              `yarn ${cdkYarnCommand} deploy ${stack.stackName} --no-execute --change-set-name ${sanitizedStackName} --require-approval never`,
+              '# Detect the package-manager runner for the CDK CLI (pnpm/yarn/npm)',
+              `if [ -f pnpm-lock.yaml ]; then CDK_RUN="pnpm exec ${cdkYarnCommand}"; elif [ -f yarn.lock ]; then CDK_RUN="yarn ${cdkYarnCommand}"; else CDK_RUN="npx ${cdkYarnCommand}"; fi`,
+              `$CDK_RUN deploy ${stack.stackName} --no-execute --change-set-name ${sanitizedStackName} --require-approval never`,
               '',
               '# Look up real CF stack name from cdk.out manifest (authoritative source)',
               'CF_STACK_NAME=""',

--- a/src/CdkDriftDetectionWorkflow.ts
+++ b/src/CdkDriftDetectionWorkflow.ts
@@ -175,7 +175,21 @@ export class CdkDriftDetectionWorkflow {
             uses: `actions/setup-node@${githubActionsSetupNodeVersion}`,
             with: { 'node-version': nodeVersion },
           },
-          { name: 'Install dependencies', if: condExpr, run: 'yarn install --frozen-lockfile || npm ci', env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' } },
+          {
+            name: 'Install dependencies',
+            if: condExpr,
+            run: [
+              'if [ -f pnpm-lock.yaml ]; then',
+              '  corepack enable',
+              '  pnpm install --frozen-lockfile',
+              'elif [ -f yarn.lock ]; then',
+              '  yarn install --frozen-lockfile',
+              'else',
+              '  npm ci',
+              'fi',
+            ].join('\n'),
+            env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
+          },
           ...preSteps.map((step) => {
             const s: any = { ...(step as any) };
             s.if = s.if ?? condExpr;

--- a/test/CdkDiffStackWorkflow.test.ts
+++ b/test/CdkDiffStackWorkflow.test.ts
@@ -566,4 +566,34 @@ describe('CdkDiffStackWorkflow', () => {
     // End of the name (stack identifier) should be preserved
     expect(changeSetName).toContain('ImportantStack');
   });
+
+  test('generated workflow auto-detects pnpm for install and the CDK CLI runner', () => {
+    const app = createApp();
+
+    new CdkDiffStackWorkflow({
+      project: app,
+      stacks: [
+        {
+          stackName: 'MyStack',
+          changesetRoleToAssumeArn: 'arn:aws:iam::111122223333:role/cdk-diff-role',
+          changesetRoleToAssumeRegion: 'us-east-1',
+        },
+      ],
+      oidcRoleArn: 'arn:aws:iam::111122223333:role/github-oidc-role',
+      oidcRegion: 'us-east-1',
+    });
+
+    const wf = synthSnapshot(app)['.github/workflows/diff-mystack.yml'].toString();
+
+    // Install step handles all three package managers, pnpm first.
+    expect(wf).toContain('if [ -f pnpm-lock.yaml ]; then');
+    expect(wf).toContain('pnpm install --frozen-lockfile');
+    expect(wf).toContain('yarn install --frozen-lockfile');
+    expect(wf).toContain('npm ci');
+
+    // The CDK CLI is invoked through the detected runner (pnpm exec / yarn / npx), not a hardcoded `yarn`.
+    expect(wf).toContain('CDK_RUN="pnpm exec cdk"');
+    expect(wf).toContain('CDK_RUN="yarn cdk"');
+    expect(wf).toContain('$CDK_RUN deploy MyStack --no-execute');
+  });
 });


### PR DESCRIPTION
## Problem

The generated workflows only handled `yarn.lock` / `package-lock.json`. For a pnpm-managed CDK app (only `pnpm-lock.yaml`), the **Install dependencies** step hits the `else` branch and `exit 1`s with "No lock file found". The diff workflow additionally hardcoded a `yarn ${cdkYarnCommand}` prefix for the CDK CLI.

## Fix

Auto-detect the package manager from the lockfile — **no new public API**, fully backward compatible:

- **Install** (diff + drift): `pnpm-lock.yaml` → `corepack enable` + `pnpm install --frozen-lockfile`, falling back to `yarn install` / `npm ci` exactly as before.
- **CDK CLI** (diff): invoked via a detected runner — `pnpm exec cdk` / `yarn cdk` / `npx cdk` — instead of a fixed `yarn` prefix. yarn and npm produce the same effective command as before.

## Tests

- All 62 existing tests pass (jsii clean, eslint clean, `API.md` unchanged — confirming no API surface change).
- Added a test asserting the generated diff workflow handles pnpm for both the install step and the CDK runner.

Motivated by consuming this action in a pnpm + Rust-Lambda CDK repo.