### PR TITLE
fix(ci): exclude @aws-sdk/@smithy from Safe-Chain minimum-age check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -85,6 +86,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -127,6 +129,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -170,6 +173,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -213,6 +217,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -128,6 +129,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -179,6 +181,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -228,6 +231,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6
@@ -278,6 +282,7 @@ jobs:
       - name: Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)
         run: |-
           echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV
+          echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV
           curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
       - name: Checkout
         uses: actions/checkout@v6

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -70,6 +70,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
       name: 'Install Aikido Safe-Chain 1.5.3 (in-flight malware scanner, 7d minimum age)',
       run: [
         'echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS=168" >> $GITHUB_ENV',
+        // AWS publishes @aws-sdk/@smithy daily; the 7-day cooldown (meant for unknown
+        // malicious packages) would snag nearly every release on these trusted scopes.
+        'echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*" >> $GITHUB_ENV',
         'curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci',
       ].join('\n'),
     },


### PR DESCRIPTION
Follow-up to #205. With the parse errors fixed, the release job now runs — and fails at **Install dependencies**: Aikido Safe-Chain's 7-day `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS` blocks 8 sub-week-old `@aws-sdk`/`@smithy` transitive deps.

AWS ships these first-party scopes daily, so the cooldown (meant for *unknown* malicious packages) snags nearly every release. Excludes just those trusted scopes via `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aws-sdk/*,@smithy/*`; the cooldown still applies to everything else.

Verified: `npx projen build` green (62 tests); exclusion env now emitted in every job's bootstrap step.