### PR TITLE
fix(ci): restore Collect go artifact step clobbered by release_golang override

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,8 @@ jobs:
         run: mv dist dist.old
       - name: Create go artifact
         run: cd .repo && npx projen package:go
+      - name: Collect go artifact
+        run: mv .repo/dist dist
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -249,24 +249,27 @@ releaseWorkflow.file!.addOverride('jobs.release_golang.permissions.contents', 'w
 releaseWorkflow.file!.addOverride('jobs.release_golang.steps.0.with.node-version', workflowNodeVersion);
 
 // Replace GO_GITHUB_TOKEN PAT with GitHub App installation token for Go module publishing
-// Step 10: clear old Release step fields and repurpose as token generation
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.10.name', 'Generate token');
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.10.id', 'generate_token');
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.10.uses', 'actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5');
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.10.with', {
+// Step indices assume the Aikido Safe-Chain bootstrap step at index 4; the default
+// job layout is [... 9: Create go artifact, 10: Collect go artifact, 11: Release].
+// Step 11: clear old Release step fields and repurpose as token generation
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11.name', 'Generate token');
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11.id', 'generate_token');
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11.uses', 'actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5');
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11.with', {
   'app-id': '${{ secrets.PROJEN_APP_ID }}',
   'private-key': '${{ secrets.PROJEN_APP_PRIVATE_KEY }}',
 });
-// Remove old Release step fields from step 10
-releaseWorkflow.file!.addDeletionOverride('jobs.release_golang.steps.10.env');
-releaseWorkflow.file!.addDeletionOverride('jobs.release_golang.steps.10.run');
-// Step 11: actual release using the App token
-releaseWorkflow.file!.addOverride('jobs.release_golang.steps.11', {
+// Remove old Release step fields from step 11
+releaseWorkflow.file!.addDeletionOverride('jobs.release_golang.steps.11.env');
+releaseWorkflow.file!.addDeletionOverride('jobs.release_golang.steps.11.run');
+// Step 12: actual release using the App token
+releaseWorkflow.file!.addOverride('jobs.release_golang.steps.12', {
   name: 'Release',
   env: {
     GIT_USER_NAME: 'github-actions[bot]',
     GIT_USER_EMAIL: '41898282+github-actions[bot]@users.noreply.github.com',
     GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}',
+    PUBLIB_DRYRUN: '${{ inputs.dry_run }}',
   },
   run: [
     // publib constructs https://<token>@github.com/... which works for PATs but not GitHub App tokens.


### PR DESCRIPTION
## Problem

Release run 28727181995 (v1.11.1) published npm/PyPI/NuGet successfully, but `release_golang` failed:

```
Error: ENOENT: no such file or directory, scandir '.../dist/go'
```

## Root cause

Same bug class as #205: the `release_golang` `addOverride`s in `.projenrc.ts` still assumed the pre-Safe-Chain step layout. After the Aikido bootstrap step (#152) shifted the job's steps +1:

- `steps.10` (intended for the old **Release** step) instead landed on **Collect go artifact** (`mv .repo/dist dist`), deleting its `run` and repurposing it into **Generate token**
- the go artifact was created in `.repo/dist` but never moved to `dist/` (which had been moved to `dist.old`), so `publib-golang` found no `dist/go`

This parsed as a valid `uses` step, so #205's actionlint sweep couldn't catch it — the job ran, just without the collect step.

## Fix

- Shift the token-gen overrides to `steps.11` (repurposing the default Release step) and the App-token Release append to `steps.12`, restoring `Collect go artifact` at step 10
- Re-add `PUBLIB_DRYRUN: ${{ inputs.dry_run }}` to the Release env — the appended step no longer merges onto the default step that carried it (npm/pypi/nuget all honor it)

## Verification

- Step map of the regenerated `release_golang` job: `9 Create go artifact → 10 Collect go artifact → 11 Generate token → 12 Release`
- `actionlint .github/workflows/release.yml`: zero syntax-check errors; run+with/uses+run scan across all workflows: zero illegal steps
- `npx projen test`: 62/62 pass

Real proof is the release re-run after merge — watching `release_golang` on the v1.11.2 release.